### PR TITLE
Increase timeout for onBlur

### DIFF
--- a/lib/base-view.js
+++ b/lib/base-view.js
@@ -202,7 +202,7 @@ module.exports = function( el, options ){
       // event handlers fires before the blur event handler
       setTimeout(function(){
         this_.hide();
-      }, 100 );
+      }, 200 );
     }
   }).init();
 };


### PR DESCRIPTION
The previous timeout was inconsistent on Blink-based browsers, increased to 200ms for consistent click delegation.
